### PR TITLE
Automate Setup and Funding Processes in Stylus Workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,13 @@ For advanced/local setup:
 
 Your Codespace comes pre-configured. Open a terminal and follow the steps in each section below. If you want to run locally, review the "Requirements" section above and follow these same steps in your own environment.
 
-### Step 1: Setup
-- `git checkout step-1-setup` — Check out the initial setup branch.
-- `pnpm install -r` — Install dependencies in all `apps`.
-- `cd apps/contracts-stylus && cargo stylus check` — Verify the Rust contract setup.
+### Step 1: Start the Arbitrum Nitro Devnode
+1. Open a new terminal window in Codespaces.
+2. Start the Nitro devnode:
+   ```sh
+   pnpm --filter contracts-stylus nitro-node
+   ```
+   This will launch a local Arbitrum chain for deploying and testing your contracts.
 
 ### Step 2: Game of Life Stylus Contract
 - `git checkout step-2-stylus-contract` — Switch to the Stylus contract step.
@@ -121,10 +124,10 @@ Nitro comes with the following preloaded account:
 
 Interact with the contracts as a user by choosing a different wallet address from the deployer. Use one of the test accounts below, each with a unique address and private key.
 
-Fund these accounts with ETH from the deployer (master) account. Run this script in your Codespace terminal:
+Fund these accounts with ETH from the deployer (master) account using the following pnpm script:
 
-```bash
-./scripts/funds.sh
+```sh
+pnpm --filter contracts-stylus fund-accounts
 ```
 
 This script sends ETH from the master account to each test account so you can complete transactions during the workshop.

--- a/apps/contracts-stylus/package.json
+++ b/apps/contracts-stylus/package.json
@@ -9,7 +9,9 @@
     "test:integration:debug": "cargo test --test integration_test -- --nocapture",
     "test": "cargo test --lib",
     "nonce": "cast nonce 0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E --rpc-url http://localhost:8547",
-    "export-abi": "cargo stylus export-abi"
+    "export-abi": "cargo stylus export-abi",
+    "nitro-node": "if [ -x ../nitro-devnode/run-dev-node.sh ]; then (cd ../nitro-devnode && ./run-dev-node.sh); else echo '[ERROR] Nitro devnode not found. Please ensure apps/nitro-devnode exists and run-dev-node.sh is present.'; fi",
+    "fund-accounts": "../../scripts/funds.sh"
   },
   "dependencies": {
     "ethers": "^6.14.1"

--- a/apps/contracts-stylus/package.json
+++ b/apps/contracts-stylus/package.json
@@ -11,7 +11,7 @@
     "nonce": "cast nonce 0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E --rpc-url http://localhost:8547",
     "export-abi": "cargo stylus export-abi",
     "nitro-node": "if [ -x ../nitro-devnode/run-dev-node.sh ]; then (cd ../nitro-devnode && ./run-dev-node.sh); else echo '[ERROR] Nitro devnode not found. Please ensure ../nitro-devnode exists and run-dev-node.sh is present.'; fi",
-    "fund-accounts": "../../scripts/funds.sh"
+    "fund-accounts": "node -e \"require('child_process').execFileSync(require('path').resolve(__dirname, '../../scripts/funds.sh'), { stdio: 'inherit' })\""
   },
   "dependencies": {
     "ethers": "^6.14.1"

--- a/apps/contracts-stylus/package.json
+++ b/apps/contracts-stylus/package.json
@@ -10,7 +10,7 @@
     "test": "cargo test --lib",
     "nonce": "cast nonce 0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E --rpc-url http://localhost:8547",
     "export-abi": "cargo stylus export-abi",
-    "nitro-node": "if [ -x ../nitro-devnode/run-dev-node.sh ]; then (cd ../nitro-devnode && ./run-dev-node.sh); else echo '[ERROR] Nitro devnode not found. Please ensure apps/nitro-devnode exists and run-dev-node.sh is present.'; fi",
+    "nitro-node": "if [ -x ../nitro-devnode/run-dev-node.sh ]; then (cd ../nitro-devnode && ./run-dev-node.sh); else echo '[ERROR] Nitro devnode not found. Please ensure ../nitro-devnode exists and run-dev-node.sh is present.'; fi",
     "fund-accounts": "../../scripts/funds.sh"
   },
   "dependencies": {


### PR DESCRIPTION
### Overview

This PR automates the setup of the Arbitrum Nitro Devnode and the process of funding test accounts by introducing scripts and updating the `README.md` with clearer instructions. These updates streamline the setup and usage of the development environment.

### Changes

1. **README.md Updates:**
   - Updated the setup instructions to replace manual steps with scripts.
   - Added instructions for starting the Arbitrum Nitro Devnode using `pnpm`.

2. **New Scripts Added:**
   - `nitro-node`: Script to start the Arbitrum Nitro Devnode, now included in `package.json`.
   - `fund-accounts`: Script to fund test accounts, replacing the manual process previously shared in documentation.